### PR TITLE
Query and mesh network improvements

### DIFF
--- a/source/constants.mjs
+++ b/source/constants.mjs
@@ -111,6 +111,11 @@ const constants = {
     RUN_10_PERCENT:       4,
     RUN_STEP_NEXT_ACTIVE: 5,
     RUN_STEP_SINGLE:      6,
+
+    /* Query packet statuses */
+    PACKET_IS_DATA: 0,
+    PACKET_IS_REQUEST: 1,
+    PACKET_IS_RESPONSE: 2,
 };
 
 export default constants;

--- a/source/generate_network.mjs
+++ b/source/generate_network.mjs
@@ -40,6 +40,10 @@ import * as log from './log.mjs';
 import { get_node_distance } from './utils.mjs';
 import { rng } from './random.mjs';
 
+import dirnames from "./dirnames.mjs";
+import fs from 'fs';
+import path from 'path';
+
 function get_rssi(n1, n2)
 {
     let d = get_node_distance(n1, n2);
@@ -89,8 +93,12 @@ function distance_from_link_quality(lq)
 function initialize_random(num_nodes, area_radius)
 {
     const nodes = [];
-    for (let i = 0; i < num_nodes; ++i) {
-        const distance = rng.random() * area_radius;
+    /* first, add the gateway at the center */
+    nodes.push({pos_x: 0.0, pos_y: 0.0, distance: 0.0, angle: 0.0});
+    for (let i = 1; i < num_nodes; ++i) {
+        const u = rng.random();
+        /* to ensure uniform distribution in the circle, make nodes quadratically more likely to be in the outer rings */
+        const distance = area_radius - u * u * area_radius;
         const angle = rng.random() * Math.PI * 2;
         const pos_x = distance * Math.sin(angle);
         const pos_y = distance * Math.cos(angle);
@@ -101,9 +109,14 @@ function initialize_random(num_nodes, area_radius)
 
 function get_degrees_links(nodes)
 {
+    let i;
     const links = {};
+    const num_links_per_node = {};
     let num_good_links = 0;
-    for (let i = 0; i < nodes.length; ++i) {
+    for (i = 0; i < nodes.length; ++i) {
+        num_links_per_node[i] = 0;
+    }
+    for (i = 0; i < nodes.length; ++i) {
         const n1 = nodes[i];
         for (let j = i + 1; j < nodes.length; ++j) {
             const n2 = nodes[j];
@@ -111,51 +124,47 @@ function get_degrees_links(nodes)
             if (link.success_rate >= config.POSITIONING_LINK_QUALITY) {
                 const key = i * nodes.length + j;
                 links[key] = link;
-                num_good_links++;
+                num_good_links += 1;
+                num_links_per_node[i] += 1;
+                num_links_per_node[j] += 1;
             }
         }
     }
-    const degrees = 2 * num_good_links / nodes.length;
-    return { degrees, links };
-}
-
-function increase_degree(nodes, area_radius)
-{
-    let furthest_distance = nodes[0].distance;
-    let furthest_node = 0;
-    for (let j = 1; j < nodes.length; ++j) {
-        if (nodes[j].distance > furthest_distance) {
-            furthest_distance = nodes[j].distance;
-            furthest_node = j;
+    let num_disconnected = 0;
+    for (i = 0; i < nodes.length; ++i) {
+        if (num_links_per_node[i] === 0) {
+            num_disconnected += 1;
         }
     }
-    const angle = nodes[furthest_node].angle;
-    const distance = rng.random() * furthest_distance;
-    nodes[furthest_node].pos_x = distance * Math.sin(angle);
-    nodes[furthest_node].pos_y = distance * Math.cos(angle);
-    nodes[furthest_node].distance = distance;
-    return area_radius;
-}
-
-function decrease_degree(nodes, area_radius)
-{
-    /* increase the area size */
-    area_radius *= 1.1;
     
-    let nearest_distance = nodes[0].distance;
-    let nearest_node = 0;
-    for (let j = 1; j < nodes.length; ++j) {
-        if (nodes[j].distance < nearest_distance) {
-            nearest_distance = nodes[j].distance;
-            nearest_node = j;
+    const degrees = 2 * num_good_links / nodes.length;
+    return { degrees, links, num_disconnected, num_links_per_node };
+}
+
+function connect_node(nodes, num_links_per_node)
+{
+    let i;
+    let connected_node = null;
+    let disconnected_node = null;
+    for (i = nodes.length - 1; i >= 0; --i) {
+        if (num_links_per_node[i] === 0) {
+            disconnected_node = i;
+        } else {
+            connected_node = i;
+        }
+        if (connected_node != null && disconnected_node != null) {
+            break;
         }
     }
-    const angle = nodes[nearest_node].angle;
-    const distance = nearest_distance + rng.random() * (area_radius - nearest_distance);
-    nodes[nearest_node].pos_x = distance * Math.sin(angle);
-    nodes[nearest_node].pos_y = distance * Math.cos(angle);
-    nodes[nearest_node].distance = distance;
-    return area_radius;
+
+    if (connected_node != null && disconnected_node != null) {
+        /* move the disconnected node to a position where it has a link at least to the connected node */
+        const delta = rng.random() * (config.LOGLOSS_TRANSMIT_RANGE_M / 3);
+        nodes[disconnected_node].distance = nodes[connected_node].distance - delta;
+        nodes[disconnected_node].angle = nodes[connected_node].angle;
+        nodes[disconnected_node].pos_x = nodes[disconnected_node].distance * Math.sin(nodes[disconnected_node].angle);
+        nodes[disconnected_node].pos_y = nodes[disconnected_node].distance * Math.cos(nodes[disconnected_node].angle);
+    }
 }
 
 /*
@@ -163,7 +172,7 @@ function decrease_degree(nodes, area_radius)
  * - initialize random positions depending on the number of links expected and on the network size
  * - while not meeting the constraints, keep moving nodes (further apart or closer together)
  */
-function generate_mesh(num_nodes, degrees, area_radius=null)
+function generate_mesh(num_nodes, degrees, initial_area_radius=null)
 {
     log.log(log.INFO, null, "Main", `generating a mesh network with ${num_nodes} nodes and ${degrees} degrees`);
 
@@ -181,22 +190,47 @@ function generate_mesh(num_nodes, degrees, area_radius=null)
     }
 
     /* relax the constraint a bit and accept values close to the required */
-    const min_acceptable_degrees = Math.min(degrees - 0.5, degrees * 0.95);
-    const max_acceptable_degrees = Math.max(degrees + 0.5, degrees * 1.05);
+    const min_acceptable_degrees = Math.min(degrees - 0.5, degrees * 0.9);
+    const max_acceptable_degrees = Math.max(degrees + 0.5, degrees * 1.1);
 
-    if (!area_radius) {
-        area_radius = Math.trunc(config.LOGLOSS_TRANSMIT_RANGE_M * Math.sqrt(num_nodes) * 4 / degrees);
+    if (!initial_area_radius) {
+        initial_area_radius = Math.trunc(config.LOGLOSS_TRANSMIT_RANGE_M * Math.sqrt(num_nodes) * 3 / degrees);
     }
 
-    const nodes = initialize_random(num_nodes, area_radius);
+    let area_multiplier = 1.0;
+    let nodes = initialize_random(num_nodes, area_multiplier * initial_area_radius);
     let net = get_degrees_links(nodes);
-    while (!(min_acceptable_degrees <= net.degrees && net.degrees <= max_acceptable_degrees)) {
+    log.log(log.INFO, null, "Main", `initialized, net.degrees=${net.degrees} range=[${min_acceptable_degrees},${max_acceptable_degrees}]`);
+
+    while (!(min_acceptable_degrees <= net.degrees && net.degrees <= degrees)) {
         if (net.degrees < min_acceptable_degrees) {
-            area_radius = increase_degree(nodes, area_radius);
+            log.log(log.INFO, null, "Main", `increase degrees, current net.degrees=${net.degrees}`);
+            area_multiplier /= 1.03;
         } else {
-            area_radius = decrease_degree(nodes, area_radius);
+            log.log(log.INFO, null, "Main", `decrease degrees, current net.degrees=${net.degrees} area_multiplier=${area_multiplier}`);
+            area_multiplier *= 1.03;
         }
+        nodes = initialize_random(num_nodes, area_multiplier * initial_area_radius);
         net = get_degrees_links(nodes);
+    }
+
+    if (net.num_disconnected) {
+        log.log(log.INFO, null, "Main", `trying to fix the generated network: some nodes are disconnected`);
+    }
+
+    /* try to fix disconnected nodes */
+    while (net.num_disconnected) {
+        /* save a copy of the current state first */
+        const old_nodes = JSON.parse(JSON.stringify(nodes));
+        connect_node(nodes, net.num_links_per_node);
+        net = get_degrees_links(nodes);
+        log.log(log.INFO, null, "Main", `connected a node, new net.degrees=${net.degrees}`);
+        if (!(min_acceptable_degrees <= net.degrees && net.degrees <= max_acceptable_degrees)) {
+            /* restore to previous version of nodes */
+            log.log(log.ERROR, null, "Main", `failed to generate a connected network with ${num_nodes} nodes and ${degrees} degrees: some nodes remain disconnected`);
+            nodes = old_nodes;
+            break;
+        }
     }
 
     return nodes;
@@ -253,6 +287,31 @@ function generate_grid(num_nodes)
     return nodes;
 }
 
+function save_generated_network(nodes)
+{
+    const contents = {
+        LOGLOSS_TRANSMIT_RANGE_M: config.LOGLOSS_TRANSMIT_RANGE_M,
+        LOGLOSS_RX_SENSITIVITY_DBM: config.LOGLOSS_RX_SENSITIVITY_DBM,
+        LOGLOSS_RSSI_INFLECTION_POINT_DBM: config.LOGLOSS_RSSI_INFLECTION_POINT_DBM,
+        LOGLOSS_PATH_LOSS_EXPONENT: config.LOGLOSS_PATH_LOSS_EXPONENT,
+        AWGN_GAUSSIAN_STD: config.AWGN_GAUSSIAN_STD,
+        NODE_TYPES: [{
+            NAME: "node",
+            START_ID: 1,
+            COUNT: nodes.length,
+            CONNECTIONS: [{"NODE_TYPE": "node", "LINK_MODEL" : "LogisticLoss"}]
+        }],
+        POSITIONS: []
+    };
+    for (let i = 0; i < nodes.length; ++i) {
+        contents.POSITIONS.push({ID: i + 1, X: nodes[i].pos_x, Y: nodes[i].pos_y});
+    }
+
+    const is_child = config.SIMULATION_RUN_ID !== 0;
+    const filename = is_child ? `positions_${config.SIMULATION_RUN_ID}.json` : "positions.json";
+    fs.writeFileSync(path.join(dirnames.results_dir, filename), JSON.stringify(contents, null, 2));
+}
+
 export default function generate_network(num_nodes)
 {
     let result;
@@ -283,6 +342,11 @@ export default function generate_network(num_nodes)
     } else {
         log.log(log.ERROR, null, "Main", `unknown layout ${config.POSITIONING_LAYOUT}, ignoring; select one of: Mesh/Star/Line/Grid`);
         result = null;
+    }
+
+    if (config.SAVE_RESULTS) {
+        /* write the result to a file */
+        save_generated_network(result);
     }
 
     return result;

--- a/source/neighbor.mjs
+++ b/source/neighbor.mjs
@@ -123,7 +123,7 @@ export class Neighbor {
         this.last_tx_sec = time.timeline.seconds;
         this.freshness = Math.min(this.freshness + num_tx, FRESHNESS_MAX);
         if (is_success) {
-            this.num_tx_success++;
+            this.num_tx_success += 1;
             if (is_ack_required) {
                 /* update the Rx time, because we have received the ACK */
                 this.last_rx_sec = this.last_tx_sec;
@@ -139,7 +139,7 @@ export class Neighbor {
     on_rx(packet) {
         this.last_rssi = packet.rx_info[this.node.id].rssi;
         this.last_rx_sec = time.timeline.seconds;
-        this.num_rx++;
+        this.num_rx += 1;
 
         if (this.etx == null) {
             this.init_etx();

--- a/source/network.mjs
+++ b/source/network.mjs
@@ -167,6 +167,18 @@ export class Network {
         return this.protocol_handlers.get(key);
     }
 
+    get_time_source_tree() {
+        const result = {};
+        for (let [id, node] of this.nodes) {
+            if (node.current_time_source != null) {
+                result[id] = node.current_time_source.id;
+            } else {
+                result[id] = null;
+            }
+        }
+        return result;
+    }
+
     aggregate_stats() {
         let stats = {};
         let charge_uc = 0;

--- a/source/network.mjs
+++ b/source/network.mjs
@@ -55,6 +55,7 @@ export class Network {
     reset_stats() {
         /* statistics: end-to-end */
         this.stats_app_num_tx = 0;
+        this.stats_app_num_replied = 0;
         this.stats_app_num_endpoint_rx = 0;
         this.stats_app_num_lost = 0;
         this.stats_app_num_queue_drops = 0;
@@ -178,6 +179,7 @@ export class Network {
 
             /* statistics: end-to-end */
             this.stats_app_num_tx += node_stats.app_num_tx;
+            this.stats_app_num_replied += node_stats.app_num_replied;
             this.stats_app_num_endpoint_rx += node_stats.app_num_endpoint_rx;
             this.stats_app_num_lost += node_stats.app_num_lost;
             this.stats_app_num_queue_drops += node_stats.app_num_queue_drops;
@@ -257,6 +259,12 @@ export class Network {
                 {
                     "total": this.stats_app_num_lost,
                     "name": "Number of application packets lost"
+                }
+            ],
+            "app-packets-replied": [
+                {
+                    "total": this.stats_app_num_replied,
+                    "name": "Number of application query requests replied"
                 }
             ],
             "current-consumed": [

--- a/source/node.mjs
+++ b/source/node.mjs
@@ -540,7 +540,7 @@ export class Node {
         neighbor.backoff_window = rng.randint(0, 65536) % (1 << neighbor.backoff_exponent);
         /* Add one to the window as we will decrement it at the end of the current slot
          * through queue_update_all_backoff_windows */
-        neighbor.backoff_window++;
+        neighbor.backoff_window += 1;
     }
 
     /* Decrement backoff window for all queues directed at the cell's neighbor ID */
@@ -1605,7 +1605,8 @@ export class Node {
             if (packet.packet_protocol === constants.PROTO_APP) {
                 let nexthop = this.network.get_node(packet.nexthop_id);
                 assert(nexthop, `unknown nexthop node ${packet.nexthop_id}`);
-                const seqnum = packet.source.id + "#" + packet.seqnum;
+                const effective_source_id = (packet.query_status == constants.PACKET_IS_RESPONSE ? packet.destination_id : packet.source.id);
+                const seqnum = effective_source_id + "#" + packet.seqnum;
                 const search_set = packet.destination_id === packet.nexthop_id ?
                     nexthop.stats_app_packets_rxed :
                     nexthop.stats_app_packets_seen;

--- a/source/packet.mjs
+++ b/source/packet.mjs
@@ -90,7 +90,7 @@ export class Packet {
         this.generation_time_s = time.timeline.seconds;
         this.packet_protocol = -1;
         this.msg_type = 0;
-        this.is_query = false;
+        this.query_status = constants.PACKET_IS_DATA;
         /* 6LoWPAN fragmentation */
         this.fragment_info = null;
         /* function called when the packet is completed sending (ACKed or dropped) */
@@ -120,7 +120,7 @@ export class Packet {
         this.generation_time_s = other.generation_time_s;
         this.packet_protocol = other.packet_protocol;
         this.msg_type = other.msg_type;
-        this.is_query = other.is_query;
+        this.query_status = other.query_status;
         this.fragment_info = other.fragment_info;
         this.sent_callback = other.sent_callback;
         this.reserved_bit_set = false;

--- a/source/packet_source.mjs
+++ b/source/packet_source.mjs
@@ -34,6 +34,7 @@
  */
 
 import config from './config.mjs';
+import constants from './constants.mjs';
 import * as pkt from './packet.mjs';
 import * as log from './log.mjs';
 import * as time from './time.mjs';
@@ -81,7 +82,9 @@ export class PacketSource {
         if (do_generate) {
             const packet = new pkt.Packet(this.source, this.destination_id, this.length);
             packet.seqnum = ++this.source.seqnum_generator;
-            packet.is_query = this.is_query;
+            if (this.is_query) {
+                packet.query_status = constants.PACKET_IS_REQUEST;
+            }
             log.log(log.INFO, this.source, "App", `generate a packet, seqnum=${packet.seqnum} for=${this.destination_id}`);
             this.source.add_app_packet(packet);
         } else {

--- a/source/packet_source.mjs
+++ b/source/packet_source.mjs
@@ -81,7 +81,8 @@ export class PacketSource {
 
         if (do_generate) {
             const packet = new pkt.Packet(this.source, this.destination_id, this.length);
-            packet.seqnum = ++this.source.seqnum_generator;
+            this.source.seqnum_generator += 1;
+            packet.seqnum = this.source.seqnum_generator;
             if (this.is_query) {
                 packet.query_status = constants.PACKET_IS_REQUEST;
             }

--- a/source/route.mjs
+++ b/source/route.mjs
@@ -133,6 +133,11 @@ export class RoutingTable {
 export function periodic_process(period_seconds)
 {
     log.log(log.INFO, null, "Main", `periodic route processing for all nodes`);
+
+    const total_nodes = simulator.get_nodes().size;
+    let num_joined_tsch = 0;
+    let num_joined_routing = 0;
+
     for (const [_, node] of simulator.get_nodes()) {
         const to_remove = [];
         for (const [_, route] of node.routes.routes) {
@@ -143,9 +148,18 @@ export function periodic_process(period_seconds)
                 }
             }
         }
+        if (node.has_joined) {
+            num_joined_tsch += 1;
+            if (node.routing.is_joined()) {
+                num_joined_routing += 1;
+            }
+        }
 
         for (const rr of to_remove) {
             node.routes.remove_route(rr.prefix);
         }
     }
+
+    log.log(log.INFO, null, "Main", `joined_routing/joined_tsch/total=${num_joined_routing}/${num_joined_tsch}/${total_nodes}`);
+
 }

--- a/source/routing_rpl.mjs
+++ b/source/routing_rpl.mjs
@@ -912,6 +912,8 @@ export class RPL
             this.node.routes.remove_default_route();
             if (nbr) {
                 this.node.routes.add_default_route(nbr.neighbor.id);
+            } else {
+                mlog(log.ERROR, this.node, `drop preferred parent: rank=${this.preferred_parent.rank} link=${this.preferred_parent.link_metric()}`);
             }
 
             this.preferred_parent = nbr;
@@ -954,7 +956,11 @@ export class RPL
             }
 
             /* Now we have an acceptable parent, check if it is the new best */
-            best = this.of_best_parent(best, nbr);
+            if (best == null) {
+                best = nbr;
+            } else {
+                best = this.of_best_parent(best, nbr);
+            }
         }
 
         return best;
@@ -1148,14 +1154,10 @@ export class RPL
     }
 
     mrhof_nbr_path_cost(nbr) {
-        //mlog(log.DEBUG, this.node, `path cost: rank=${nbr.rank} metric=${nbr.link_metric()}`);
         return Math.min(nbr.rank + nbr.link_metric(), RPL_INFINITE_RANK);
     }
 
     mrhof_nbr_is_acceptable_parent(nbr) {
-        if (!nbr) {
-            return null;
-        }
         /* Exclude links with too high link metrics  */
         const has_usable_link = nbr.link_metric() <= MRHOF_MAX_LINK_METRIC;
         const path_cost = this.mrhof_nbr_path_cost(nbr);

--- a/source/routing_rpl.mjs
+++ b/source/routing_rpl.mjs
@@ -685,7 +685,7 @@ export class RPL
 
         /* Update DIO counter for redundancy mngt */
         if (dio.payload.rank !== RPL_INFINITE_RANK) {
-            this.dio_counter++;
+            this.dio_counter += 1;
         }
 
         /* The DIO has a newer version: global repair.
@@ -1302,7 +1302,7 @@ export class RPL
         } else {
             /* check if we need to double interval */
             if (this.dio_intcurrent < this.node.config.RPL_DIO_INTERVAL_MIN + this.node.config.RPL_DIO_INTERVAL_DOUBLINGS) {
-                this.dio_intcurrent++;
+                this.dio_intcurrent += 1;
             }
             this.new_dio_interval();
         }
@@ -1399,7 +1399,7 @@ export class RPL
     resend_dao() {
         this.dao_timer = null;
         /* Increment transmission counter before sending */
-        this.dao_transmissions++;
+        this.dao_transmissions += 1;
         /* Send a DAO with own prefix as target and default lifetime */
         this.dao_output(this.preferred_parent, this.node.config.RPL_DEFAULT_LIFETIME_MIN);
 

--- a/source/routing_rpl.mjs
+++ b/source/routing_rpl.mjs
@@ -378,13 +378,13 @@ export class RPL
             if (route) {
                 /* A DAO route was found so we set the down flag. */
                 rpl_opt_flags |= RPL_HDR_OPT_DOWN;
-                mlog(log.DEBUG, this.node, `going down according to RPL: from=${this.node.id} to=${route.nexthop_id}`);
+                mlog(log.DEBUG, this.node, `going down according to RPL: via=${packet.lasthop_id}->${this.node.id}->${route.nexthop_id}`);
             } else {
                 /* No route was found, so this packet will go towards the RPL
                    root. If so, we should not set the down flag. */
                 rpl_opt_flags &= ~RPL_HDR_OPT_DOWN;
                 const nexthop_id = this.node.routes.default_route ? this.node.routes.default_route.nexthop_id : -1;
-                mlog(log.DEBUG, this.node, `going up according to RPL: from=${this.node.id} to=${nexthop_id}`);
+                mlog(log.DEBUG, this.node, `going up according to RPL: via=${packet.lasthop_id}->${this.node.id}->${nexthop_id}`);
             }
         }
 

--- a/source/scheduler_orchestra.mjs
+++ b/source/scheduler_orchestra.mjs
@@ -518,6 +518,8 @@ function special_for_root_init_on_root(node)
     const timeslot = 0;
     const local_channel_offset = unicast_get_node_channel_offset(node.addr);
 
+    mlog(log.INFO, node, `special for root rule: initialize on the root`);
+
     node.add_cell(sf_rx,
                   constants.CELL_OPTION_RX,
                   constants.CELL_TYPE_NORMAL,
@@ -874,7 +876,7 @@ export function initialize()
         /* ORCHESTRA_RULES: [ "orchestra_rule_eb_per_time_source",
                               "orchestra_rule_unicast_per_neighbor_link_based",
                               "orchestra_rule_default_common" ], */
-        /* Example configuration for RPL non-storing mode: */
+        /* Example configuration for RPL non-storing mode (works also for the storing one): */
         /* ORCHESTRA_RULES:  [ "orchestra_rule_eb_per_time_source",
                                "orchestra_rule_unicast_per_neighbor_rpl_ns",
                                "orchestra_rule_default_common" ], */

--- a/source/simulator.mjs
+++ b/source/simulator.mjs
@@ -245,7 +245,7 @@ export function construct_simulation(is_from_web)
             previous_id = id;
             net.add_node(id, type_config);
             type_ids[node_type.NAME].push(id);
-            id++;
+            id += 1;
         }
 
         if (!net.mobility_model && type_config.MOBILITY_MODEL && type_config.MOBILITY_MODEL !== "Static") {

--- a/source/simulator.mjs
+++ b/source/simulator.mjs
@@ -307,10 +307,7 @@ export function construct_simulation(is_from_web)
         /* Generate default some packet sources for a data collection application */
         for (let i = 2; i <= net.nodes.size; ++i) {
             /* packet sources */
-            const period_sec = config.APP_PACKET_PERIOD_SEC;
-            new ps.PacketSource(net.get_node(i),
-                                net.get_node(1),
-                                period_sec, false, false, config.APP_PACKET_SIZE);
+            new ps.PacketSource(net.get_node(i), net.get_node(1));
         }
     }
 
@@ -355,6 +352,8 @@ export function construct_simulation(is_from_web)
             const data = from_node_type.APP_PACKETS;
             const period_sec = "APP_PACKET_PERIOD_SEC" in data ? data.APP_PACKET_PERIOD_SEC : config.APP_PACKET_PERIOD_SEC;
             const size = "APP_PACKET_SIZE" in data ? data.APP_PACKET_SIZE : config.APP_PACKET_SIZE;
+            const warmup_period = "APP_WARMUP_PERIOD_SEC" in data ? data.APP_WARMUP_PERIOD_SEC : config.APP_WARMUP_PERIOD_SEC;
+
             const is_query = "IS_QUERY" in data ? data.IS_QUERY : false;
             if ("TO_TYPE" in data) {
                 const to_type = data.TO_TYPE;
@@ -364,7 +363,7 @@ export function construct_simulation(is_from_web)
                         if (from_node_id !== to_node_id) {
                             new ps.PacketSource(net.get_node(from_node_id),
                                                 net.get_node(to_node_id),
-                                                period_sec, false, is_query, size);
+                                                period_sec, false, is_query, size, warmup_period);
                         }
                     }
                 }
@@ -376,7 +375,7 @@ export function construct_simulation(is_from_web)
                         if (from_node_id !== to_node_id) {
                             new ps.PacketSource(net.get_node(from_node_id),
                                                 to_node_id === -1 ? null : net.get_node(to_node_id),
-                                                period_sec, false, is_query, size);
+                                                period_sec, false, is_query, size, warmup_period);
                         }
                     }
                 } else {

--- a/source/utils.mjs
+++ b/source/utils.mjs
@@ -158,10 +158,11 @@ Array.prototype.sum = Array.prototype.sum || function (){
 };
 
 Array.prototype.avg = Array.prototype.avg || function () {
-    return this.sum() / (this.length || 1);
+    return this.length ? this.sum() / this.length : null;
 };
 
 Array.prototype.min = Array.prototype.min || function () {
+    if (!this.length) return null;
     let len = this.length;
     let result = Infinity;
     while (len--) {
@@ -173,6 +174,7 @@ Array.prototype.min = Array.prototype.min || function () {
 };
 
 Array.prototype.max = Array.prototype.max || function () {
+    if (!this.length) return null;
     let len = this.length;
     let result = -Infinity;
     while (len--) {
@@ -185,7 +187,7 @@ Array.prototype.max = Array.prototype.max || function () {
 
 Array.prototype.percentile = Array.prototype.percentile || function (percent) {
     if (!this.length) {
-        return 0.0;
+        return null;
     }
     this.sort();
     const k = (this.length - 1) * percent / 100.0;

--- a/tests/applications/Makefile
+++ b/tests/applications/Makefile
@@ -15,7 +15,8 @@ dissemination: dissemination.json
 query: query.json
 	rm -rf results
 	../../tsch-sim.sh $< > /dev/null
-	$(NODE) --harmony --experimental-modules  ../check_pdr.mjs results/stats.json 90
+	$(NODE) --harmony --experimental-modules  ../check_pdr.mjs results/stats.json 90 1
+	$(NODE) --harmony --experimental-modules  ../check_stats_value.mjs results/stats.json -1 app_num_replied \> 0
 
 clean:
 	rm -rf results

--- a/tests/check_stats_value.mjs
+++ b/tests/check_stats_value.mjs
@@ -6,6 +6,7 @@ import fs from 'fs';
 import process from 'process';
 
 const RUN_ID = "0";
+const ROOT_ID = "1";
 
 if (process.argv.length < 6) {
     console.log("results file, node ID, stat name and value not supplied");
@@ -15,20 +16,41 @@ if (process.argv.length < 6) {
 const filedata = fs.readFileSync(process.argv[2]);
 const node_id = parseInt(process.argv[3]).toString();
 const stat_name = process.argv[4];
-const required_stat_value = parseFloat(process.argv[5]);
+const op = process.argv[5];
+const required_stat_value = parseFloat(process.argv[6]);
 
 const state = JSON.parse(filedata);
 const run_state = state[RUN_ID];
 let is_any_valid = false;
 
 for (let key in run_state) {
-    if (key !== node_id) continue;
+    if (node_id == -1) {
+        if (key === "global-stats" || key === ROOT_ID) continue;
+    } else {
+        if (key !== node_id) continue;
+    }
 
     const stat_value = run_state[key][stat_name];
-    if (stat_value !== required_stat_value) {
-        console.log(`For ${stat_name} value ${stat_value} is not equal to required value ${required_stat_value}`);
+    if (op == "=") {
+        if (!(stat_value == required_stat_value)) {
+            console.log(`For "${stat_name}" value ${stat_value} is not equal to required value ${required_stat_value}`);
+            process.exit(1);
+        }
+    } else if (op == ">") {
+        if (!(stat_value > required_stat_value)) {
+            console.log(`For "${stat_name}" value ${stat_value} is not greater than required value ${required_stat_value}`);
+            process.exit(1);
+        }
+    } else if (op == "<") {
+        if (!(stat_value < required_stat_value)) {
+            console.log(`For "${stat_name}" value ${stat_value} is not lesser than required value ${required_stat_value}`);
+            process.exit(1);
+        }
+    } else {
+        console.log(`Unknown op ${op} for ${stat_name}`);
         process.exit(1);
     }
+
     is_any_valid = true;
 }
 

--- a/tests/generation/Makefile
+++ b/tests/generation/Makefile
@@ -5,7 +5,7 @@ all: mesh grid star line
 mesh: mesh.json
 	rm -rf results
 	../../tsch-sim.sh $< > /dev/null
-	grep "set position x=-407.19 y=-61.38" results/log.txt > /dev/null
+	grep "set position x=-445.05 y=-96.50" results/log.txt > /dev/null
 
 grid: grid.json
 	rm -rf results

--- a/tests/stats/Makefile
+++ b/tests/stats/Makefile
@@ -5,8 +5,8 @@ all: duty-cycle
 duty-cycle: duty-cycle.json
 	rm -rf results
 	../../tsch-sim.sh $< > /dev/null
-	$(NODE) --harmony --experimental-modules  ../check_stats_value.mjs results/stats.json 1 radio_duty_cycle 2.02
-	$(NODE) --harmony --experimental-modules  ../check_stats_value.mjs results/stats.json 1 radio_duty_cycle_joined 2.02
+	$(NODE) --harmony --experimental-modules  ../check_stats_value.mjs results/stats.json 1 radio_duty_cycle = 2.02
+	$(NODE) --harmony --experimental-modules  ../check_stats_value.mjs results/stats.json 1 radio_duty_cycle_joined = 2.02
 
 clean:
 	rm -rf results

--- a/tsch-sim.sh
+++ b/tsch-sim.sh
@@ -8,7 +8,7 @@ if [ "$#" -lt 1 ]; then
     exit 1
 fi
 
-CONFIG_FILE=$(realpath $1)
+CONFIG_FILE=$(realpath "$1")
 if [ -d "$CONFIG_FILE" ] ; then
     CONFIG_FILE=$CONFIG_FILE/config.json
 fi


### PR DESCRIPTION
The following are addressed:

1) Improve the query traffic pattern. Used to be broken.
2) Improve mesh network autogeneration: use uniform density, and try to recognize and avoid disconnected nodes by moving them around.
3) Export the time source tree at the end of the simulation. The tree is exported in Graghviz dot format in order to allow easy vizualizations of the time source tree.