### PR TITLE
Orchestra: changes in when the orchestra_parent_knows_us flag is set

### DIFF
--- a/source/scheduler_orchestra.mjs
+++ b/source/scheduler_orchestra.mjs
@@ -729,6 +729,11 @@ export function on_tx(node, packet, status_ok)
 {
     const RPL_CODE_DAO                = 0x02; /* Destination Advertisement Option */
 
+    if (node.config.RPL_WITH_DAO_ACK) {
+        /* wait for DAO ACK in this case */
+        return;
+    }
+
     /* check if our parent just ACKed a DAO */
     if (packet.packet_protocol === constants.PROTO_ICMP6
         && packet.msg_type === RPL_CODE_DAO
@@ -748,7 +753,18 @@ export function on_tx(node, packet, status_ok)
 
 export function on_rx(node, packet)
 {
-    /* nothing */
+    const RPL_CODE_DAO_ACK            = 0x03; /* DAO acknowledgment */
+
+    if (packet.packet_protocol === constants.PROTO_ICMP6
+        && packet.msg_type === RPL_CODE_DAO_ACK) {
+
+        if (node.orchestra_parent_linkaddr != null
+            && addr_equal(packet.nexthop_addr, node.orchestra_parent_linkaddr)) {
+            /* yes! */
+            mlog(log.DEBUG, node, `parent sent a DAO ACK: parent definately knows us!`);
+            node.orchestra_parent_knows_us = true;
+        }
+    }
 }
 
 /* ------------------------------------------------- */


### PR DESCRIPTION
At the moment the child always set the orchestra_parent_knows_us flag when getting a MAC-level ACK to the DAO packet. However, the DAO packet may be dropped by the higher layers, and a route to the child not added - for instance, because the routing table is already full!

This PR aims to improve this logic, and in case DAO ACKs are enabled, set the orchestra_parent_knows_us flag only upon reception of a DAO ACK.

This is a draft PR, as it's not clear whether this tradeoff is worth doing in practice.