### PR TITLE
Orchestra: add ORCHESTRA_UNICAST_ACTIVE_PERIOD configuration setting

### DIFF
--- a/tests/scheduling/Makefile
+++ b/tests/scheduling/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.include
 
-all: orchestra-rb-ns orchestra-rb-storing orchestra-sb-storing orchestra-special-for-root orchestra-link-based lf 6tisch-min 100percent-line 100percent-star
+all: orchestra-rb-ns orchestra-nondefault-periods orchestra-active-period orchestra-rb-storing orchestra-sb-storing orchestra-special-for-root orchestra-link-based lf 6tisch-min 100percent-line 100percent-star
 
 orchestra-rb-ns: orchestra-rb-ns.json
 	@echo "\nTest group '$(shell basename `pwd`)', test target '$@'..."
@@ -8,6 +8,24 @@ orchestra-rb-ns: orchestra-rb-ns.json
 	../../tsch-sim.sh $< > /dev/null
 	grep "initializing rule unicast per neighbor non-storing" results/log.txt > /dev/null
 	$(NODE) --harmony --experimental-modules  ../check_pdr.mjs results/stats.json 90.0
+
+orchestra-nondefault-periods: orchestra-with-nondefault-periods.json
+	@echo "\nTest group '$(shell basename `pwd`)', test target '$@'..."
+	@rm -rf results
+	../../tsch-sim.sh $< > /dev/null
+	grep "initializing rule EB per time source (handle=0 slotframe_size=299)" results/log.txt > /dev/null
+	grep "initializing rule unicast per neighbor non-storing (handle=1 slotframe_size=7)" results/log.txt > /dev/null
+	grep "initializing rule default common (handle=2 slotframe_size=17)" results/log.txt > /dev/null
+	$(NODE) --harmony --experimental-modules  ../check_pdr.mjs results/stats.json 90.0
+
+orchestra-active-period: orchestra-with-shorter-active-period.json
+	@echo "\nTest group '$(shell basename `pwd`)', test target '$@'..."
+	@rm -rf results
+	../../tsch-sim.sh $< > /dev/null
+	grep "using a shorter active period for unicast frames: 7 vs 17" results/log.txt > /dev/null
+	grep "initializing rule unicast per neighbor non-storing" results/log.txt > /dev/null
+	$(NODE) --harmony --experimental-modules  ../check_pdr.mjs results/stats.json 90.0
+
 
 orchestra-rb-storing: orchestra-rb-storing.json
 	@echo "\nTest group '$(shell basename `pwd`)', test target '$@'..."

--- a/tests/scheduling/orchestra-with-nondefault-periods.json
+++ b/tests/scheduling/orchestra-with-nondefault-periods.json
@@ -1,0 +1,36 @@
+{
+    "SIMULATION_DURATION_SEC": 1200,
+    "RESULTS_DIR": "./results",
+    "APP_WARMUP_PERIOD_SEC" : 300,
+
+    "ORCHESTRA_EBSF_PERIOD": 299,
+    "ORCHESTRA_COMMON_SHARED_PERIOD": 17,
+    "ORCHESTRA_UNICAST_PERIOD": 7,
+
+    "NODE_TYPES": [
+        {
+            "NAME": "node",
+            "START_ID": 1,
+            "COUNT": 10,
+            "CONNECTIONS" : [{"NODE_TYPE": "node", "LINK_MODEL": "UDGM"}],
+            "ORCHESTRA_RULES": [
+                "orchestra_rule_eb_per_time_source",
+                "orchestra_rule_unicast_per_neighbor_rpl_ns",
+                "orchestra_rule_default_common"
+            ],
+            "APP_PACKETS": {"APP_PACKET_PERIOD_SEC": 10, "TO_ID": 1}
+        }
+    ],
+    "POSITIONS" : [
+        {"ID": 1, "X": 0, "Y": 0},
+        {"ID": 2, "X": 40, "Y": 0},
+        {"ID": 3, "X": 0, "Y": 40},
+        {"ID": 4, "X": -40, "Y": 0},
+        {"ID": 5, "X": 80, "Y": 0},
+        {"ID": 6, "X": 80, "Y": 0},
+        {"ID": 7, "X": 0, "Y": 80},
+        {"ID": 8, "X": 0, "Y": 80},
+        {"ID": 9, "X": -80, "Y": 0},
+        {"ID": 10, "X": -80, "Y": 0}
+    ]
+}

--- a/tests/scheduling/orchestra-with-shorter-active-period.json
+++ b/tests/scheduling/orchestra-with-shorter-active-period.json
@@ -1,0 +1,33 @@
+{
+    "SIMULATION_DURATION_SEC": 1200,
+    "RESULTS_DIR": "./results",
+    "APP_WARMUP_PERIOD_SEC" : 300,
+    "ORCHESTRA_UNICAST_PERIOD": 17,
+    "ORCHESTRA_UNICAST_ACTIVE_PERIOD": 7,
+    "NODE_TYPES": [
+        {
+            "NAME": "node",
+            "START_ID": 1,
+            "COUNT": 10,
+            "CONNECTIONS" : [{"NODE_TYPE": "node", "LINK_MODEL": "UDGM"}],
+            "ORCHESTRA_RULES": [
+                "orchestra_rule_eb_per_time_source",
+                "orchestra_rule_unicast_per_neighbor_rpl_ns",
+                "orchestra_rule_default_common"
+            ],
+            "APP_PACKETS": {"APP_PACKET_PERIOD_SEC": 10, "TO_ID": 1}
+        }
+    ],
+    "POSITIONS" : [
+        {"ID": 1, "X": 0, "Y": 0},
+        {"ID": 2, "X": 40, "Y": 0},
+        {"ID": 3, "X": 0, "Y": 40},
+        {"ID": 4, "X": -40, "Y": 0},
+        {"ID": 5, "X": 80, "Y": 0},
+        {"ID": 6, "X": 80, "Y": 0},
+        {"ID": 7, "X": 0, "Y": 80},
+        {"ID": 8, "X": 0, "Y": 80},
+        {"ID": 9, "X": -80, "Y": 0},
+        {"ID": 10, "X": -80, "Y": 0}
+    ]
+}


### PR DESCRIPTION
If the value of `ORCHESTRA_UNICAST_ACTIVE_PERIOD` is set lower than the size of the unicast slotframe (`ORCHESTRA_UNICAST_PERIOD`), then all active slots are grouped in the specific part of the slotframe.